### PR TITLE
aws-iot-core-credential-provider-session-helper 0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 [tool.poetry]
 name = "awsiot-credentialhelper"
-version = "0.6.0"
+version = "0.7.0"
 description = "AWS IoT Core Credential Provider Session Helper"
 authors = ["Gavin Adams <gavinaws@amazon.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
*Issue #, if available:*

- Security updates

*Description of changes:*

- Dependency updates to more current code for `awsiotsdk` and `boto3`
- Python 3.12 now supported


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
